### PR TITLE
Feature/add i principal provider has value

### DIFF
--- a/.github/workflows/stize.dotnet.CD.yml
+++ b/.github/workflows/stize.dotnet.CD.yml
@@ -1,11 +1,9 @@
-name: stize.dotnet.CI
+name: stize.dotnet.CD
 
 on:
   push:
-    branches-ignore:
-      - 'release/**'
-    tags:
-      - '**'
+    branches:
+      - 'release/*'
 
 jobs:
   build:
@@ -41,7 +39,7 @@ jobs:
             dotnet pack ${{ env.sln }} -p:PackageVersion=${{steps.version.outputs.version}}
 
             
-      - name: push private
+      - name: push nuget.org
         run: |
-            dotnet nuget add source https://nuget.pkg.github.com/stize/index.json -n github -u stize -p ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
-            until dotnet nuget push "./artifacts/build/*.nupkg" --source "github" --skip-duplicate --no-symbols true; do echo "Retrying"; sleep 1; done
+            until dotnet nuget push "./artifacts/build/*.nupkg" --api-key ${{ secrets.NUGETORG_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json; do echo "Retrying"; sleep 1; done
+            until dotnet nuget push "./artifacts/build/*.snupkg" --api-key ${{ secrets.NUGETORG_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json; do echo "Retrying"; sleep 1; done

--- a/.github/workflows/stize.dotnet.CD.yml
+++ b/.github/workflows/stize.dotnet.CD.yml
@@ -1,9 +1,8 @@
 name: stize.dotnet.CD
 
 on:
-  push:
-    branches:
-      - 'release/*'
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/stize.dotnet.CI.yml
+++ b/.github/workflows/stize.dotnet.CI.yml
@@ -2,8 +2,6 @@ name: stize.dotnet.CI
 
 on:
   push:
-    branches-ignore:
-      - 'release/**'
     tags:
       - '**'
 

--- a/src/Hosting/AspNetCore/Http/PrincipalProvider.cs
+++ b/src/Hosting/AspNetCore/Http/PrincipalProvider.cs
@@ -13,5 +13,10 @@ namespace Stize.Hosting.AspNetCore.Http
             this.accessor = accessor;
         }
         public IPrincipal Current => this.accessor.HttpContext.User;
+
+        /// <summary>
+        /// Gets a value indicating whether the current IPrincipal object has a valid value.
+        /// </summary>
+        public bool HasValue => this.accessor != null && this.accessor.HttpContext != null && this.accessor.HttpContext.User != null;
     }
 }


### PR DESCRIPTION
Sometimes if you're working in asynchronous contexts and the developer is using this property to get the **IPrincipalProvide.Current** an exception will be thrown because HTTPContext is null,
