### PR TITLE
Added validations.

### DIFF
--- a/src/Hosting/AspNetCore/Http/PrincipalProvider.cs
+++ b/src/Hosting/AspNetCore/Http/PrincipalProvider.cs
@@ -12,6 +12,12 @@ namespace Stize.Hosting.AspNetCore.Http
         {
             this.accessor = accessor;
         }
-        public IPrincipal Current => this.accessor.HttpContext.User;
+        public IPrincipal Current => this.accessor.HttpContext?.User;
+
+        /// <summary>
+        /// Gets a value indicating whether the current IPrincipal object has a valid value.
+        /// </summary>
+        public bool HasValue => this.accessor != null && this.accessor.HttpContext != null && this.accessor.HttpContext.User != null;
+
     }
 }


### PR DESCRIPTION
Sometimes if you're working in asynchronous contexts and the developer is using this property to get the IPrincipalProvide.Current an exception will be thrown because HTTPContext is null,